### PR TITLE
Automated Changelog Entry for 0.2.0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0
+
+([Full Changelog](https://github.com/jupyter/notebook_shim/compare/v0.1.0...1853b2e5fcab1de80fd8803d04dc95662d39903a))
+
+### Enhancements made
+
+- raise ceiling on jupyter_server dependency to < 3 [#12](https://github.com/jupyter/notebook_shim/pull/12) ([@Zsailer](https://github.com/Zsailer))
+
+### Maintenance and upkeep improvements
+
+- remove dev version [#15](https://github.com/jupyter/notebook_shim/pull/15) ([@Zsailer](https://github.com/Zsailer))
+- switch to hatch build backend [#14](https://github.com/jupyter/notebook_shim/pull/14) ([@Zsailer](https://github.com/Zsailer))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter/notebook_shim/graphs/contributors?from=2022-02-10&to=2022-09-09&type=c))
+
+[@Zsailer](https://github.com/search?q=repo%3Ajupyter%2Fnotebook_shim+involves%3AZsailer+updated%3A2022-02-10..2022-09-09&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0
 
 ([Full Changelog](https://github.com/jupyterlab/notebook_shim/compare/first-commit...5b433fa298f741c7d71c9a3e7e85f17b2207300f))
@@ -24,5 +45,3 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab/notebook_shim/graphs/contributors?from=2022-01-19&to=2022-02-10&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fnotebook_shim+involves%3Ajtpio+updated%3A2022-01-19..2022-02-10&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fnotebook_shim+involves%3Awelcome+updated%3A2022-01-19..2022-02-10&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyterlab%2Fnotebook_shim+involves%3AZsailer+updated%3A2022-01-19..2022-02-10&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter/notebook_shim  |
| Branch  | main  |
| Version Spec | 0.2.0 |
| Since | v0.1.0 |