### PR TITLE
Fix extension discovery warning

### DIFF
--- a/notebook_shim/__init__.py
+++ b/notebook_shim/__init__.py
@@ -1,4 +1,4 @@
-def _jupyter_server_extension_paths():
+def _jupyter_server_extension_points():
     return [
         {
             'module': 'notebook_shim.nbserver',


### PR DESCRIPTION
This updates the extension point discovery method to eliminate warnings from Jupyter Server.

```
[W 2024-02-08 15:26:50.519 ServerApp] A `_jupyter_server_extension_points` function was not found in notebook_shim. Instead, a `_jupyter_server_extension_paths` function was found and will be used for now. This function name will be deprecated in future releases of Jupyter Server.
```